### PR TITLE
mark owner object as changed when attributes are changed

### DIFF
--- a/src/Extensions/Attributable.php
+++ b/src/Extensions/Attributable.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
 
 class Attributable extends DataExtension
 {
@@ -147,6 +148,12 @@ class Attributable extends DataExtension
         $existing = Attribution::get_from_pair($this->owner, $attribute);
         if ($existing) {
             $this->owner->Attributions()->remove($existing);
+            // mark owner as changed
+            if ($this->owner->hasExtension(Versioned::class)) {
+                $this->owner->writeToStage(Versioned::DRAFT);
+            } else {
+                $this->owner->write();
+            }
         }
     }
 
@@ -175,6 +182,12 @@ class Attributable extends DataExtension
         $attribution->write();
 
         $this->owner->Attributions()->add($attribution);
+        // mark owner as changed
+        if ($this->owner->hasExtension(Versioned::class)) {
+            $this->owner->writeToStage(Versioned::DRAFT);
+        } else {
+            $this->owner->write();
+        }
 
         return $attribution;
     }


### PR DESCRIPTION
This solves the issue where the owner object is not marked as changed when attributes are changed. 

This is a bit ugly because we create a new version of the owner object even though there are no changes on the actual object, but from a user's point of view it makes a lot more sense to see the "modified" label on an object when they changed the attributes.

It's somwhat related to https://github.com/silverstripe/silverstripe-versioned/issues/195, but I dodn't want to use that suggested (experimental) module https://github.com/silverstripe/silverstripe-versioned-snapshots because it never reached stable and doesn't seem to be maintained.